### PR TITLE
PE-171

### DIFF
--- a/edx-platform/pearson-theme/lms/templates/emails/account_creation_and_enroll_emailMessage.txt
+++ b/edx-platform/pearson-theme/lms/templates/emails/account_creation_and_enroll_emailMessage.txt
@@ -1,0 +1,18 @@
+<%! from django.utils.translation import ugettext as _ %>
+
+${_("Welcome to {course_name}").format(course_name=course.display_name_with_default_escaped)}
+
+${_("To get started, please visit https://{site_name}. The login information for your account follows.").format(site_name=site_name)}
+
+${_("email: {email}").format(email=email_address)}
+${_("password: {password}").format(password=password)}
+
+${_("Then click \"SIGN IN\" (not REGISTER)")}
+
+${_("It is recommended that you change your password.")}
+
+${_("To change your password, click on the Hamburger menu in the top right corner and select Account. Scroll down to \"Password\" and click the \"Reset Your Password\" button. An email will be generated prompting you to reset your password.")}
+
+${_("Sincerely yours,"
+""
+"The {course_name} Team").format(course_name=course.display_name_with_default_escaped)}


### PR DESCRIPTION
Override account_creation_and_enroll_emailMessage.txt email template content.
For more info view ticket https://proversity.atlassian.net/browse/PE-171
It has already been tested in development.