### PR TITLE
PE-665 - Hiding the CCX master courses from the dashboard.

### DIFF
--- a/edx-platform/pearson-pols-theme/lms/templates/dashboard.html
+++ b/edx-platform/pearson-pols-theme/lms/templates/dashboard.html
@@ -150,9 +150,26 @@ share_settings = configuration_helpers.get_value(
 'SOCIAL_SHARING_SETTINGS',
 getattr(settings, 'SOCIAL_SHARING_SETTINGS', {})
 )
+show_ccx_master_courses = user.profile.get_meta().get('show_ccx_master_courses', 'hide')
+ccx_courses = user.customcourseforedx_set.filter(coach_id=user.id) if show_ccx_master_courses == 'hide' else []
 %>
 
 % for dashboard_index, enrollment in enumerate(course_entitlements + course_enrollments):
+<%
+  is_master_course = False
+%>
+
+% if not getattr(enrollment.course_id, 'ccx', None):
+    % for ccx_course in ccx_courses:
+      <%
+        is_master_course = enrollment.course_id == ccx_course.course_id
+      %>
+    % endfor
+%endif
+
+% if is_master_course:
+  <% continue %>
+% endif
 
 <div class="items course single-course">
 


### PR DESCRIPTION
## Description:

This PR adds the option to hide the CCX master course from the dashboard to the coach users.
It checks for the extended profile field called show_ccx_master_courses to show or hide the master courses; by default it will hide the CCX master courses.

## Reviewers:

- [ ] @andrey-canon 