### PR TITLE
PAE-125 - Filter if the user is staff in the master course.

### DIFF
--- a/edx-platform/pearson-pols-theme/lms/templates/ccx/enrollment.html
+++ b/edx-platform/pearson-pols-theme/lms/templates/ccx/enrollment.html
@@ -90,14 +90,16 @@ from openedx.core.djangolib.markup import HTML, Text
             </tr>
           </thead>
           <tbody>
+            <%!
+            hide_staff_users = configuration_helpers.get_value('HIDE_MASTER_COURSE_STAFF_FROM_STUDENT_LIST', False)
+            %>
             %for member in ccx_members:
+              % if hide_staff_users and (member.user.is_staff or get_user_role(member.user, course) != 'student'):
+                <% continue %>
+              % endif
             <tr>
               <td>${member.user}</td>
-              % if not member.user.is_staff and get_user_role(member.user, course) == 'student':
-                <td>${member.user.email}</td>
-              % else:
-                <td>${_("This email is private.")}</td>
-              %endif
+              <td>${member.user.email}</td>
               % if configuration_helpers.get_value('ALLOW_CCX_REVOKE_ACCESS', True):
                 <td><button type="button" class="revoke"><span class="fa fa-times-circle" aria-hidden="true"></span>${_("Revoke access")}</button></td>
               %endif


### PR DESCRIPTION
## Description:

This PR adds functionality to filter if the user is staff in the master course to avoid showing it in the Student management list.

## Configuration:

This functionality is handled by a site configuration setting: HIDE_MASTER_COURSE_STAFF_FROM_STUDENT_LIST set it to 'true' if you want to hide staff users of the course master from Student management list.

## Reviewers:

- [ ] @andrey-canon 
- [ ] @diegomillan 