### PR TITLE
PAE-245 - Add language selector and improve footer template.

### DIFF
--- a/edx-platform/pearson-kaust-theme/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/edx-platform/pearson-kaust-theme/lms/static/sass/partials/lms/theme/_extras.scss
@@ -8,12 +8,13 @@
 
 @import 'navigation';
 @import 'login-register';
+@import 'footer';
 
 @import url("https://fonts.googleapis.com/css?family=Lato:boldLato:bold,normal");
 @import url("https://fonts.googleapis.com/css?family=Lato:boldLato:bold,normal");
 
 h1, h2, h3, h4 {
-  font-family: "Lato", "Helvetica", Sans-Serif;
+  font-family: $font-family-sans-serif;
   font-weight: bold;
   font-style: normal;
   color: $primary;
@@ -21,7 +22,7 @@ h1, h2, h3, h4 {
 }
 
 body {
-  font-family: "Lato", "Helvetica", Sans-Serif;
+  font-family: $font-family-sans-serif;
   font-weight: normal;
   font-style: normal;
   font-size: 14px;
@@ -1690,7 +1691,7 @@ section {
 }
 
 h1, h2, h3, h4 {
-  font-family: "Lato", "Helvetica", Sans-Serif;
+  font-family: $font-family-sans-serif;
   font-weight: bold;
   font-style: normal;
   color: $primary;
@@ -1698,7 +1699,7 @@ h1, h2, h3, h4 {
 }
 
 h1 {
-  font-family: "Lato", "Helvetica", Sans-Serif;
+  font-family: $font-family-sans-serif;
   font-weight: 400;
   font-style: normal;
   color: #000;
@@ -1706,25 +1707,25 @@ h1 {
 }
 
 h2 {
-  font-family: "Lato", "Helvetica", Sans-Serif;
+  font-family: $font-family-sans-serif;
   font-weight: 400;
   font-style: normal;
   color: #000;
 }
 
 h3 {
-  font-family: "Lato", "Helvetica", Sans-Serif;
+  font-family: $font-family-sans-serif;
   font-weight: 400;
   font-style: normal;
   color: #000;
-  font-family: "Lato", "Helvetica", Sans-Serif;
+  font-family: $font-family-sans-serif;
   font-weight: 400;
   font-style: normal;
   color: #000;
 }
 
 body {
-  font-family: "Lato", "Helvetica", Sans-Serif;
+  font-family: $font-family-sans-serif;
   font-weight: normal;
   font-style: normal;
   font-size: 14px;
@@ -3499,7 +3500,7 @@ div.info-wrapper section.handouts ol li p div.hitarea:hover + h4:visited, p div.
 
 .wrapper-course-material .course-tabs {
   li a {
-    font-family: "Lato", "Helvetica", Sans-Serif;
+    font-family: $font-family-sans-serif;
 
     &:hover {
       color: $primary;
@@ -4456,7 +4457,7 @@ input[name="subject"] {
 }
 
 body, p, label {
-  font-family: "Lato", "Helvetica", Sans-Serif;
+  font-family: $font-family-sans-serif;
   font-size: 14px;
 }
 
@@ -6350,94 +6351,6 @@ iframe {
   li {
     display: inline-block;
     padding: 0 15px 0 0;
-  }
-}
-
-.footer {
-  background: #4e5759;
-  position: static;
-  text-align: center;
-  color: #fff;
-
-  .container {
-    max-width: 1170px !important;
-    padding: 0;
-
-    p {
-      text-align: center;
-      color: #fff;
-
-      a {
-        color: #fff;
-        text-decoration: none;
-
-        &:hover, &:focus {
-          color: #fff;
-        }
-      }
-    }
-
-    ul {
-      list-style-type: none;
-      margin: 0 0 15px 0;
-      padding: 0;
-
-      li {
-        display: inline-block;
-        padding: 0 15px 0 0;
-        color: #fff;
-
-        &:last-child {
-          padding: 0;
-        }
-
-        a {
-          color: #fff;
-          text-decoration: none;
-
-          &:hover, &:focus {
-            color: #fff;
-          }
-        }
-      }
-    }
-
-    .sponsors li {
-      &:first-child {
-        padding: 0 5px 0 0;
-      }
-
-      &:last-child {
-        padding: 0 0 0 5px;
-      }
-    }
-
-    .grid {
-      display: -webkit-box !important;
-      display: -moz-box !important;
-      display: -ms-flexbox !important;
-      display: flex !important;
-
-      .items {
-        min-height: 1px;
-
-        ul {
-          width: 100%;
-        }
-      }
-    }
-  }
-}
-
-@media (max-width: 480px) {
-  .footer .container ul li {
-    display: inline;
-  }
-}
-
-@media (max-width: 480px) {
-  .footer .container .sponsors li a img {
-    width: 45%;
   }
 }
 

--- a/edx-platform/pearson-kaust-theme/lms/static/sass/partials/lms/theme/_footer.scss
+++ b/edx-platform/pearson-kaust-theme/lms/static/sass/partials/lms/theme/_footer.scss
@@ -1,0 +1,31 @@
+// Styles for footer templates.
+
+.wrapper-footer {
+  box-shadow: none;
+  border-top: none;
+  background-color: $pearson-grey;
+  margin-top: initial;
+  padding: $baseline;
+
+  footer {
+    .footer-about-openedx {
+      float: initial;
+    }
+
+    .navbar-nav {
+      margin: 0 auto;
+    }
+
+    .site-nav {
+      .nav-item {
+        .nav-link {
+          color: $inverse;
+        }
+      }
+    }
+
+    .copyright {
+      color: $inverse;
+    }
+  }
+}

--- a/edx-platform/pearson-kaust-theme/lms/static/sass/partials/lms/theme/_variables.scss
+++ b/edx-platform/pearson-kaust-theme/lms/static/sass/partials/lms/theme/_variables.scss
@@ -29,7 +29,7 @@ $lighter-base-font-color: $secondary;
 $color-button-upgrade: #008638;
 $btn-brand-focus-border-color: rgba(210, 219, 14, 0.5);
 $btn-brand-focus-background: rgba(210, 219, 14, 0.5);
-$pearson-grey: grey;
+$pearson-grey: #6a6d6d;
 $color-hover-icon-courses:#BFBFBF;
 $pearson-grey-font:#ccc;
 $pearson-grey-courseware: #e7e7e7;
@@ -89,7 +89,7 @@ $m-blue:$primary;
 
 
 // Theme fonts
-$font-family-sans-serif: Open Sans;
+$font-family-sans-serif: "Lato", "Helvetica", Sans-Serif;
 $serif: Playfair Display;
 
 //navigation

--- a/edx-platform/pearson-kaust-theme/lms/templates/footer.html
+++ b/edx-platform/pearson-kaust-theme/lms/templates/footer.html
@@ -4,137 +4,131 @@
   from django.urls import reverse
   from django.utils.translation import ugettext as _
   from branding.api import get_footer
-  from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
-  from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+  from openedx.core.djangoapps.lang_pref.api import footer_language_selector_is_enabled
 %>
 <% footer = get_footer(is_secure=is_secure) %>
-<%namespace name='static' file='/static_content.html'/>
+<%namespace name='static' file='static_content.html'/>
 
-<footer class="footer" aria-label="${_("Page Footer")}"
-    ## When rendering the footer through the branding API,
-    ## the direction may not be set on the parent element,
-    ## so we set it here.
-    % if bidi:
-      dir=${bidi}
-    % endif
-  >
-  <div class="container">
-
-    % if configuration_helpers.get_value('FOOTER_ALIGNMENT', 'center') == 'center':
-      <div class="grid">
-        <div class="items">
-          <div>
-            <ul>
-              <li><a href="" target="_blank">${_("About")}</a></li>
-              <li><a href="" target="_blank">${_("Contact")}</a></li>
-                % if user.is_authenticated:
-                <li><a href="${marketing_link('EULA')}" target="_blank">${_("Terms of Service")}</a></li>
-              % else:
-                <li><a href="${marketing_link('TOS')}" target="_blank">${_("Terms of Service")}</a></li>
-              % endif
-              <li><a href="${marketing_link('PRIVACY')}" target="_blank">${_("Privacy Policy")}</a></li>
-              <li><a href="${marketing_link('COOKIES')}" target="_blank">${_("Cookie Policy")}</a></li>
+% if uses_bootstrap:
+  <div class="container-fluid wrapper-footer">
+    <footer>
+      <div class="row">
+        <div class="col-md-9">
+          <nav class="navbar site-nav navbar-expand-sm" aria-label="${_('About')}">
+            <ul class="navbar-nav">
+              % for item_num, link in enumerate(footer['navigation_links'], start=1):
+                <li class="nav-item">
+                  <a class="nav-link" href="${link['url']}">${link['title']}</a>
+                </li>
+              % endfor
             </ul>
+          </nav>
 
-            <ul>
-              % if configuration_helpers.get_value('ENABLE_EXTEND_SIDEBAR_MENU', False):
-                % for menu_item in configuration_helpers.get_value('EXTENDED_MENU', []):
-                  <% display_name, url = menu_item.split(",") %>
-                  <li>
-                    <a href="${url}" target="blank">${_(display_name)}</a>
-                  </li>
-                % endfor
-              % endif
-            </ul>
+          ## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
+          <p class="copyright">${footer['copyright']} ${u" | {icp}".format(icp=getattr(settings,'ICP_LICENSE')) if getattr(settings,'ICP_LICENSE',False) else ""}</p>
 
-            <ul class="sponsors">
-              <li><a href="https://proversity.org/" target="_blank"><img src="${static.url('images/proversity.svg')}" /></a></li>
-              <li><a href="${footer['openedx_link']['url']}" target="_blank"><img src="${static.url('images/openedx.svg')}" /></a></li>
+          <nav class="navbar legal-nav navbar-expand-sm" aria-label="${_('Legal')}">
+            <ul class="navbar-nav">
+              % for item_num, link in enumerate(footer['legal_links'], start=1):
+                <li class="nav-item">
+                  <a class="nav-link" href="${link['url']}">${link['title']}</a>
+                </li>
+              % endfor
+              <li class="nav-item">
+                <a class="nav-link" href="${footer['edx_org_link']['url']}">${footer['edx_org_link']['text']}</a>
+              </li>
             </ul>
-          </div>
+          </nav>
+        </div>
+        <div class="col-md-3">
+          ## Please leave this link and use one of the logos provided
+          ## The OpenEdX link may be hidden when this view is served
+          ## through an API to partner sites (such as marketing sites or blogs),
+          ## which are not technically powered by Open edX.
+          % if not hide_openedx_link:
+            <div class="footer-about-openedx">
+              <p>
+                <a href="${footer['openedx_link']['url']}">
+                  <img src="${footer['openedx_link']['image']}" alt="${footer['openedx_link']['title']}" width="140" />
+                </a>
+              </p>
+            </div>
+          % endif
         </div>
       </div>
-    % elif configuration_helpers.get_value('FOOTER_ALIGNMENT', 'center') == 'left':
-      <div class="grid double">
-        <div class="items">
-          <div>
-            <ul>
-              <li><a href="" target="_blank">${_("About")}</a></li>
-              <li><a href="" target="_blank">${_("Contact")}</a></li>
-                % if user.is_authenticated:
-                <li><a href="${marketing_link('EULA')}" target="_blank">${_("Terms of Service")}</a></li>
-              % else:
-                <li><a href="${marketing_link('TOS')}" target="_blank">${_("Terms of Service")}</a></li>
-              % endif
-              <li><a href="${marketing_link('PRIVACY')}" target="_blank">${_("Privacy Policy")}</a></li>
-              <li><a href="${marketing_link('COOKIES')}" target="_blank">${_("Cookie Policy")}</a></li>
-            </ul>
-
-            <ul>
-              % if configuration_helpers.get_value('ENABLE_EXTEND_SIDEBAR_MENU', False):
-                % for menu_item in configuration_helpers.get_value('EXTENDED_MENU', []):
-                  <% display_name, url = menu_item.split(",") %>
-                  <li>
-                    <a href="${url}" target="blank">${_(display_name)}</a>
-                  </li>
-                % endfor
-              % endif
-            </ul>
-          </div>
-        </div>
-
-        <div class="items">
-          <div>
-            <ul class="sponsors">
-              <li><a href="https://proversity.org/" target="_blank"><img src="${static.url('images/proversity.svg')}" /></a></li>
-              <li><a href="${footer['openedx_link']['url']}" target="_blank"><img src="${static.url('images/openedx.svg')}" /></a></li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    % elif configuration_helpers.get_value('FOOTER_ALIGNMENT', 'center') == 'right':
-      <div class="grid double reverse">
-        <div class="items">
-          <div>
-            <ul>
-              <li><a href="" target="_blank">${_("About")}</a></li>
-              <li><a href="" target="_blank">${_("Contact")}</a></li>
-                % if user.is_authenticated:
-                <li><a href="${marketing_link('EULA')}" target="_blank">${_("Terms of Service")}</a></li>
-              % else:
-                <li><a href="${marketing_link('TOS')}" target="_blank">${_("Terms of Service")}</a></li>
-              % endif
-              <li><a href="${marketing_link('PRIVACY')}" target="_blank">${_("Privacy Policy")}</a></li>
-              <li><a href="${marketing_link('COOKIES')}" target="_blank">${_("Cookie Policy")}</a></li>
-            </ul>
-
-            <ul>
-              % if configuration_helpers.get_value('ENABLE_EXTEND_SIDEBAR_MENU', False):
-                % for menu_item in configuration_helpers.get_value('EXTENDED_MENU', []):
-                  <% display_name, url = menu_item.split(",") %>
-                  <li>
-                    <a href="${url}" target="blank">${_(display_name)}</a>
-                  </li>
-                % endfor
-              % endif
-            </ul>
-          </div>
-        </div>
-
-        <div class="items">
-          <div>
-            <ul class="sponsors">
-              <li><a href="https://proversity.org/" target="_blank"><img src="${static.url('images/proversity.svg')}" /></a></li>
-              <li><a href="${footer['openedx_link']['url']}" target="_blank"><img src="${static.url('images/openedx.svg')}" /></a></li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    % endif
-
+    </footer>
   </div>
-</footer>
+% else:
+  <div class="wrapper wrapper-footer">
+    <footer id="footer-openedx" class="grid-container"
+      ## When rendering the footer through the branding API,
+      ## the direction may not be set on the parent element,
+      ## so we set it here.
+      % if bidi:
+        dir=${bidi}
+      % endif
+    >
+      <div class="colophon">
+        <nav class="nav-colophon" aria-label="${_('About')}">
+          <ol>
+              % for item_num, link in enumerate(footer['navigation_links'], start=1):
+              <li class="nav-colophon-0${item_num}">
+                <a id="${link['name']}" href="${link['url']}">${link['title']}</a>
+              </li>
+              % endfor
+          </ol>
+        </nav>
 
+        % if context.get('include_language_selector', footer_language_selector_is_enabled()):
+            <%include file="${static.get_template_path('widgets/footer-language-selector.html')}"/>
+        % endif
+
+        <div class="wrapper-logo">
+          <p>
+            <a href="/">
+              ## The default logo is a placeholder.
+              ## You can either replace this link entirely or update
+              ## the FOOTER_ORGANIZATION_IMAGE in Django settings.
+              ## If you customize FOOTER_ORGANIZATION_IMAGE, then the image
+              ## can be included in the footer on other sites
+              ## (e.g. a blog or marketing front-end) to provide a consistent
+              ## user experience.  See the branding app for details.
+              <img alt="organization logo" src="${footer['logo_image']}">
+            </a>
+          </p>
+        </div>
+
+        ## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
+        <p class="copyright">${footer['copyright']} ${u" | {icp}".format(icp=getattr(settings,'ICP_LICENSE')) if getattr(settings,'ICP_LICENSE',False) else ""}</p>
+
+        <nav class="nav-legal" aria-label="${_('Legal')}">
+          <ul>
+            % for item_num, link in enumerate(footer['legal_links'], start=1):
+              <li class="nav-legal-0${item_num}">
+                <a href="${link['url']}">${link['title']}</a>
+              </li>
+            % endfor
+            <li><a href="${footer['edx_org_link']['url']}">${footer['edx_org_link']['text']}</a></li>
+          </ul>
+        </nav>
+      </div>
+
+      ## Please leave this link and use one of the logos provided
+      ## The OpenEdX link may be hidden when this view is served
+      ## through an API to partner sites (such as marketing sites or blogs),
+      ## which are not technically powered by OpenEdX.
+      % if not hide_openedx_link:
+      <div class="footer-about-openedx">
+        <p>
+          <a href="${footer['openedx_link']['url']}">
+            <img src="${footer['openedx_link']['image']}" alt="${footer['openedx_link']['title']}" width="140" />
+          </a>
+        </p>
+      </div>
+      % endif
+    </footer>
+  </div>
+% endif
 % if include_dependencies:
   <%static:js group='base_vendor'/>
   <%static:css group='style-vendor'/>
@@ -146,104 +140,3 @@
     <link rel="stylesheet" type="text/css" href="${url}"></link>
   % endfor
 % endif
-
-<script>
-  // custom script
-</script>
-
-% if settings.FEATURES.get('ENABLE_COOKIE_CONSENT', False):
-<!-- Cookie Consent -->
-<link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.1/cookieconsent.min.css" />
-<script src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.1/cookieconsent.min.js"></script>
-<script>
-  window.cookieconsent.initialise({
-    palette:{
-      popup: {background: "#323538", text: "#ffffff"},
-      button: {background: "#001E62"},
-    },
-    theme: "classic"
-  });
-  $('.cc-window').css("font-family", $('body').css('fontFamily'));
-</script>
-% endif
-
-% if False:
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=GOOGLE_TRACKING_ID"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'GOOGLE_TRACKING_ID');
-</script>
-% endif
-
-<% languages = released_languages() %>
-
-<script>
-  function setLanguage(data) {
-    $.ajax({
-      type: 'POST',
-      url: '/i18n/setlang/',
-      data: data,
-      dataType: 'html',
-      success: function() {
-        location.reload();
-      },
-      error: function() {}
-    });
-  }
-
-  function prefLanguage(data, setLangData) {
-    $.ajax({
-      type: 'PATCH',
-      url: '/lang_pref/session_language/',
-      data: JSON.stringify(data),
-      contentType: "application/json",
-      success: function() {
-        setLanguage(setLangData);
-      },
-      error: function() {}
-    });
-  }
-
-  function prefUserLanguage(data, setLangData) {
-    $.ajax({
-      type: 'PATCH',
-      url: '/api/user/v1/preferences/${user.username}' ,
-      data: JSON.stringify(data),
-      contentType: "application/merge-patch+json",
-      success: function() {
-        prefLanguage(data, setLangData);
-      },
-      error: function() {}
-    });
-  }
-
-  % for language in languages:
-    $( "#lang-${language[0]}" ).click(function(e) {
-      e.preventDefault()
-      var data = {
-        'pref-lang': '${language[0]}',
-        'csrfmiddlewaretoken': '${csrf_token}'
-      };
-
-      var setLangData = { 'language': '${language[0]}' };
-      % if user.is_authenticated:
-        prefUserLanguage(data, setLangData);
-      % else:
-        prefLanguage(data, setLangData);
-      % endif
-    });
-  % endfor
-
-  $(document).ready(function () {
-    var sideBarLanguageSelector = $("#sideBarLanguageSelector .selected a").text();
-    $("#sideBarSelectedLanguage").text(sideBarLanguageSelector);
-
-    var navBarLanguageSelector = $("#navBarLanguageSelector .selected a").text();
-    $("#navBarSelectedLanguage").text(navBarLanguageSelector);
-  })
-
-</script>

--- a/edx-platform/pearson-kaust-theme/lms/templates/footer.html
+++ b/edx-platform/pearson-kaust-theme/lms/templates/footer.html
@@ -5,130 +5,82 @@
   from django.utils.translation import ugettext as _
   from branding.api import get_footer
   from openedx.core.djangoapps.lang_pref.api import footer_language_selector_is_enabled
+  from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>
 <% footer = get_footer(is_secure=is_secure) %>
+<% footer_available_links = configuration_helpers.get_value('FOOTER_AVAILABLE_LINKS') %>
 <%namespace name='static' file='static_content.html'/>
 
-% if uses_bootstrap:
-  <div class="container-fluid wrapper-footer">
-    <footer>
-      <div class="row">
-        <div class="col-md-9">
-          <nav class="navbar site-nav navbar-expand-sm" aria-label="${_('About')}">
-            <ul class="navbar-nav">
-              % for item_num, link in enumerate(footer['navigation_links'], start=1):
-                <li class="nav-item">
-                  <a class="nav-link" href="${link['url']}">${link['title']}</a>
-                </li>
-              % endfor
-            </ul>
-          </nav>
-
-          ## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
-          <p class="copyright">${footer['copyright']} ${u" | {icp}".format(icp=getattr(settings,'ICP_LICENSE')) if getattr(settings,'ICP_LICENSE',False) else ""}</p>
-
-          <nav class="navbar legal-nav navbar-expand-sm" aria-label="${_('Legal')}">
-            <ul class="navbar-nav">
-              % for item_num, link in enumerate(footer['legal_links'], start=1):
-                <li class="nav-item">
-                  <a class="nav-link" href="${link['url']}">${link['title']}</a>
-                </li>
-              % endfor
-              <li class="nav-item">
-                <a class="nav-link" href="${footer['edx_org_link']['url']}">${footer['edx_org_link']['text']}</a>
-              </li>
-            </ul>
-          </nav>
-        </div>
-        <div class="col-md-3">
-          ## Please leave this link and use one of the logos provided
-          ## The OpenEdX link may be hidden when this view is served
-          ## through an API to partner sites (such as marketing sites or blogs),
-          ## which are not technically powered by Open edX.
-          % if not hide_openedx_link:
-            <div class="footer-about-openedx">
-              <p>
-                <a href="${footer['openedx_link']['url']}">
-                  <img src="${footer['openedx_link']['image']}" alt="${footer['openedx_link']['title']}" width="140" />
-                </a>
-              </p>
-            </div>
-          % endif
-        </div>
-      </div>
-    </footer>
-  </div>
-% else:
-  <div class="wrapper wrapper-footer">
-    <footer id="footer-openedx" class="grid-container"
-      ## When rendering the footer through the branding API,
-      ## the direction may not be set on the parent element,
-      ## so we set it here.
-      % if bidi:
-        dir=${bidi}
-      % endif
-    >
-      <div class="colophon">
-        <nav class="nav-colophon" aria-label="${_('About')}">
-          <ol>
-              % for item_num, link in enumerate(footer['navigation_links'], start=1):
-              <li class="nav-colophon-0${item_num}">
-                <a id="${link['name']}" href="${link['url']}">${link['title']}</a>
-              </li>
-              % endfor
-          </ol>
+<div class="container-fluid wrapper-footer">
+  <footer>
+    <div class="row">
+      <div class="col-12">
+      % if footer_available_links:
+        <nav class="navbar site-nav navbar-expand-sm" aria-label="${_('About')} ${_('Legal')}">
+          <ul class="navbar-nav">
+          % for item in footer_available_links:
+            <li class="nav-item">
+              <a class="nav-link" href="${item['url']}">${_(item['title'])}</a>
+            </li>
+          % endfor
+          </ul>
         </nav>
 
         % if context.get('include_language_selector', footer_language_selector_is_enabled()):
             <%include file="${static.get_template_path('widgets/footer-language-selector.html')}"/>
         % endif
 
-        <div class="wrapper-logo">
-          <p>
-            <a href="/">
-              ## The default logo is a placeholder.
-              ## You can either replace this link entirely or update
-              ## the FOOTER_ORGANIZATION_IMAGE in Django settings.
-              ## If you customize FOOTER_ORGANIZATION_IMAGE, then the image
-              ## can be included in the footer on other sites
-              ## (e.g. a blog or marketing front-end) to provide a consistent
-              ## user experience.  See the branding app for details.
-              <img alt="organization logo" src="${footer['logo_image']}">
-            </a>
-          </p>
-        </div>
+        ## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
+        <p class="copyright text-center">${footer['copyright']} ${u" | {icp}".format(icp=getattr(settings,'ICP_LICENSE')) if getattr(settings,'ICP_LICENSE',False) else ""}</p>
+      % else:
+        <nav class="navbar site-nav navbar-expand-sm" aria-label="${_('About')}">
+          <ul class="navbar-nav">
+            % for item_num, link in enumerate(footer['navigation_links'], start=1):
+              <li class="nav-item">
+                <a class="nav-link" href="${link['url']}">${link['title']}</a>
+              </li>
+            % endfor
+          </ul>
+        </nav>
+
+        % if context.get('include_language_selector', footer_language_selector_is_enabled()):
+            <%include file="${static.get_template_path('widgets/footer-language-selector.html')}"/>
+        % endif
 
         ## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
         <p class="copyright">${footer['copyright']} ${u" | {icp}".format(icp=getattr(settings,'ICP_LICENSE')) if getattr(settings,'ICP_LICENSE',False) else ""}</p>
 
-        <nav class="nav-legal" aria-label="${_('Legal')}">
-          <ul>
+        <nav class="navbar legal-nav navbar-expand-sm" aria-label="${_('Legal')}">
+          <ul class="navbar-nav">
             % for item_num, link in enumerate(footer['legal_links'], start=1):
-              <li class="nav-legal-0${item_num}">
-                <a href="${link['url']}">${link['title']}</a>
+              <li class="nav-item">
+                <a class="nav-link" href="${link['url']}">${link['title']}</a>
               </li>
             % endfor
-            <li><a href="${footer['edx_org_link']['url']}">${footer['edx_org_link']['text']}</a></li>
+            <li class="nav-item">
+              <a class="nav-link" href="${footer['edx_org_link']['url']}">${footer['edx_org_link']['text']}</a>
+            </li>
           </ul>
         </nav>
-      </div>
-
-      ## Please leave this link and use one of the logos provided
-      ## The OpenEdX link may be hidden when this view is served
-      ## through an API to partner sites (such as marketing sites or blogs),
-      ## which are not technically powered by OpenEdX.
-      % if not hide_openedx_link:
-      <div class="footer-about-openedx">
-        <p>
-          <a href="${footer['openedx_link']['url']}">
-            <img src="${footer['openedx_link']['image']}" alt="${footer['openedx_link']['title']}" width="140" />
-          </a>
-        </p>
-      </div>
       % endif
-    </footer>
-  </div>
-% endif
+      </div>
+      <div class="col-12 text-center">
+        ## Please leave this link and use one of the logos provided
+        ## The OpenEdX link may be hidden when this view is served
+        ## through an API to partner sites (such as marketing sites or blogs),
+        ## which are not technically powered by Open edX.
+        % if not hide_openedx_link:
+          <div class="footer-about-openedx">
+            <a href="${footer['openedx_link']['url']}">
+              <img src="${static.url('images/openedx.svg')}" alt="${footer['openedx_link']['title']}" width="140" />
+            </a>
+          </div>
+        % endif
+      </div>
+    </div>
+  </footer>
+</div>
+
 % if include_dependencies:
   <%static:js group='base_vendor'/>
   <%static:css group='style-vendor'/>

--- a/edx-platform/pearson-kaust-theme/lms/templates/navigation/navigation.html
+++ b/edx-platform/pearson-kaust-theme/lms/templates/navigation/navigation.html
@@ -60,3 +60,6 @@ site_status_msg = get_site_status_msg(course_id)
 % endif
 
 <%include file="../help_modal.html"/>
+% if settings.FEATURES.get('ENABLE_COOKIE_CONSENT', False):
+  <%include file="../widgets/cookie-consent.html" />
+% endif


### PR DESCRIPTION
## Description:

This PR adds support for the language selector in the footer and migrate the footer template to the current Ironwood version.
Sets the default value $font-family-sans-serif.
Changes the position of the cookie consent banner to the top of the page.

## Note:

To make footer links configurable without MKTG_SITE enabled, a new site configuration was added: FOOTER_AVAILABLE_LINKS

## Configuration:

In the site configuration interface:

```
"FOOTER_AVAILABLE_LINKS": [
    {
      "title":"Link title",
      "url":"Link URL"
    }...
]
```

## Reviewers:

- [ ] @diegomillan 
- [ ] @luismorenolopera 