### PR TITLE
PAE-245 - Adding some tweaks to the Kaust theme.

### DIFF
--- a/edx-platform/pearson-kaust-theme/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/edx-platform/pearson-kaust-theme/lms/static/sass/partials/lms/theme/_extras.scss
@@ -9,6 +9,7 @@
 @import 'navigation';
 @import 'login-register';
 @import 'footer';
+@import 'support';
 
 @import url("https://fonts.googleapis.com/css?family=Lato:boldLato:bold,normal");
 @import url("https://fonts.googleapis.com/css?family=Lato:boldLato:bold,normal");
@@ -499,43 +500,6 @@ input[type="submit"], input[type="button"], button, .button, .btn {
   margin: 40px 0 20px 0;
 }
 
-.panel-title {
-  text-align: center;
-  font-weight: normal;
-}
-
-.panel-group .panel {
-  border-radius: 0;
-
-  > .open {
-    background: $primary;
-    color: #000;
-    border: 1px solid $primary;
-  }
-}
-
-.panel-heading {
-  background: #6a6d6d !important;
-  border: #6a6d6d !important;
-  color: $primary !important;
-  border-radius: 0;
-  text-align: center;
-  -webkit-transition: all 0.1s;
-  -o-transition: all 0.1s;
-  transition: all 0.1s;
-
-  &:hover, &:focus {
-    background: $primary;
-    color: #000;
-  }
-}
-
-.panel-body form {
-  input, textarea {
-    border: 1px solid #000;
-  }
-}
-
 section {
   position: relative;
   padding: 15px 0;
@@ -596,29 +560,6 @@ section {
 
       .row {
         margin: 30px 0;
-      }
-    }
-  }
-
-  &[role="highlight"] {
-    background: #6a6d6d;
-    padding: 15px 0;
-    margin: 0 -20px;
-
-    .container {
-      .row div {
-        h2, h3 {
-          text-align: center;
-          color: #fff;
-        }
-
-        p {
-          color: #fff;
-        }
-      }
-
-      .carousel .carousel-inner .item .row div .course {
-        margin: 15px 0;
       }
     }
   }
@@ -4439,15 +4380,6 @@ form {
   }
 }
 
-input[name="subject"] {
-  width: 100%;
-}
-
-.panel-body form textarea {
-  width: 100%;
-  margin: 15px 0 0 0;
-}
-
 .course-content .bookmark-button:before {
   padding-right: 5px;
 }
@@ -5134,10 +5066,6 @@ textarea[name="specific_learners"] {
   margin: 15px 0;
 }
 
-input[name="subject"] {
-  text-align: left;
-}
-
 .xmodule_edit.xmodule_HtmlDescriptor .editor {
   margin: 15px 17px 0 15px;
 }
@@ -5442,17 +5370,6 @@ input[name="subject"] {
 label {
   &[for="register-honor_code"], &[for="toggle_optional_fields"] {
     display: inline-block;
-  }
-}
-
-.feedback_form {
-  input[type="text"] {
-    width: 100%;
-    border: 1px solid #ddd;
-  }
-
-  textarea {
-    border: 1px solid #ddd !important;
   }
 }
 

--- a/edx-platform/pearson-kaust-theme/lms/static/sass/partials/lms/theme/_footer.scss
+++ b/edx-platform/pearson-kaust-theme/lms/static/sass/partials/lms/theme/_footer.scss
@@ -3,7 +3,7 @@
 .wrapper-footer {
   box-shadow: none;
   border-top: none;
-  background-color: $pearson-grey;
+  background-image: linear-gradient(to right, $primary, $primary-gradient);
   margin-top: initial;
   padding: $baseline;
 
@@ -20,6 +20,10 @@
       .nav-item {
         .nav-link {
           color: $inverse;
+
+          &:hover {
+            color: $pearson-grey;
+          }
         }
       }
     }

--- a/edx-platform/pearson-kaust-theme/lms/static/sass/partials/lms/theme/_navigation.scss
+++ b/edx-platform/pearson-kaust-theme/lms/static/sass/partials/lms/theme/_navigation.scss
@@ -58,7 +58,7 @@
   right: 0;
   width: 0;
   height: 100%;
-  background: #6a6d6d;
+  background: $inverse;
   z-index: 9999;
   overflow-x: hidden;
   -webkit-transition: all 0.3s;
@@ -69,7 +69,7 @@
 
   h1, h2 {
     text-align: center !important;
-    color: #fff;
+    color: $primary-black;
   }
 
   img {
@@ -92,12 +92,12 @@
     }
 
     li {
-      border-bottom: 1px solid #fff;
+      border-bottom: 1px solid $primary-black;
 
       a {
         display: block;
         padding: 15px;
-        color: #fff !important;
+        color: $primary-black !important;
         -webkit-transition: all 0.3s;
         -o-transition: all 0.3s;
         transition: all 0.3s;
@@ -246,7 +246,7 @@
     right: 25px;
     font-size: 36px;
     margin-left: 50px;
-    color: #fff !important;
+    color: $primary-black !important;
     z-index: 5;
 
     &:hover, &:focus {

--- a/edx-platform/pearson-kaust-theme/lms/static/sass/partials/lms/theme/_support.scss
+++ b/edx-platform/pearson-kaust-theme/lms/static/sass/partials/lms/theme/_support.scss
@@ -1,0 +1,35 @@
+// Styles for the support modal.
+
+// Overwriting Bootstrap styles.
+.modal-open {
+  overflow: hidden;
+  padding-right: 0 !important;
+}
+
+.panel-heading {
+  background: $pearson-grey;
+  padding: 5px;
+  margin: 10px 0;
+  -webkit-transition: all 0.1s;
+  -o-transition: all 0.1s;
+  transition: all 0.1s;
+
+  .panel-title {
+    color: white;
+    text-align: center;
+    font-weight: normal;
+  }
+}
+
+#feedback_form {
+  input {
+    width: 100%;
+    text-align: initial;
+  }
+
+  textarea[name="details"] {
+    height: 150px;
+    width: 100%;
+    border: 1px solid $pearson-grey-courseware-2;
+  }
+}


### PR DESCRIPTION
## Description:

This PR adds some tweaks such as:

- Menu: Change the menu background-colour from Grey to white, and the text-colour to black.
- Course Card Section (Home Screen): Change the background-colour of the section to white.
- Footer Section: Change the background-colour of the footer section to the same orange gradient as the top (header) section. The text-color will remain as white.
- Support Box: Change the text color in the support box buttons to white, as the orange text is unreadable on the grey buttons. can we please also have padding around the text in the buttons, as they are right on the edge of the buttons

## Reviewers:

- [ ] @diegomillan 
- [ ] @luismorenolopera 