### PR TITLE
PAE-245 - Reset content-wrapper width value of the Kaust theme.

### DIFF
--- a/edx-platform/pearson-kaust-theme/lms/static/sass/partials/lms/theme/_index.scss
+++ b/edx-platform/pearson-kaust-theme/lms/static/sass/partials/lms/theme/_index.scss
@@ -33,6 +33,9 @@
 }
 
 .content-wrapper {
+  // Reset max-width value.
+  max-width: initial;
+
   &.main-container {
     margin-top: 0;
   }


### PR DESCRIPTION
## Description:

This PR resets the width value of the content-wrapper, because the current value is: 1920px and it conflicts with larger screens and the zoom out browser option.

## Front-end changes:

**Before:**

![image](https://user-images.githubusercontent.com/17520199/91768722-ae9ddf80-eba3-11ea-9ec5-b760342275b9.png)

**After:**

![image](https://user-images.githubusercontent.com/17520199/91768793-c8d7bd80-eba3-11ea-98d7-f35238c13ced.png)

## Reviewers:

- [ ] @luismorenolopera 
- [ ] @diegomillan 