### PR TITLE
Adding FAQ page to Cabinet

### DIFF
--- a/edx-platform/cabinet-theme/lms/templates/footer.html
+++ b/edx-platform/cabinet-theme/lms/templates/footer.html
@@ -26,7 +26,7 @@
           <div>
             <ul>
               <li><a href="" target="_blank">${_("About")}</a></li>
-              <li><a href="mailto:commselearning@cabinetoffice.gov.uk" target="_blank">${_("Contact")}</a></li>
+              <li><a href="${marketing_link('FAQ')}" target="_blank">${_("FAQ")}</a></li>
               <li><a href="${marketing_link('HONOR')}" target="_blank">${_("Terms of Service and Honour Code")}</a></li>
               <li><a href="${marketing_link('PRIVACY')}" target="_blank">${_("Privacy Policy")}</a></li>
               <li><a href="${marketing_link('COOKIES')}" target="_blank">${_("Cookie Policy")}</a></li>
@@ -56,7 +56,7 @@
           <div>
             <ul>
               <li><a href="" target="_blank">${_("About")}</a></li>
-              <li><a href="mailto:commselearning@cabinetoffice.gov.uk" target="_blank">${_("Contact")}</a></li>
+              <li><a href="${marketing_link('FAQ')}" target="_blank">${_("FAQ")}</a></li>
               <li><a href="${marketing_link('HONOR')}" target="_blank">${_("Terms of Service and Honour Code")}</a></li>
               <li><a href="${marketing_link('PRIVACY')}" target="_blank">${_("Privacy Policy")}</a></li>
               <li><a href="${marketing_link('COOKIES')}" target="_blank">${_("Cookie Policy")}</a></li>
@@ -90,7 +90,7 @@
           <div>
             <ul>
               <li><a href="" target="_blank">${_("About")}</a></li>
-              <li><a href="mailto:commselearning@cabinetoffice.gov.uk" target="_blank">${_("Contact")}</a></li>
+              <li><a href="${marketing_link('FAQ')}" target="_blank">${_("FAQ")}</a></li>
               <li><a href="${marketing_link('HONOR')}" target="_blank">${_("Terms of Service and Honour Code")}</a></li>
               <li><a href="${marketing_link('PRIVACY')}" target="_blank">${_("Privacy Policy")}</a></li>
               <li><a href="${marketing_link('COOKIES')}" target="_blank">${_("Cookie Policy")}</a></li>

--- a/edx-platform/cabinet-theme/lms/templates/navigation/navbar-not-authenticated.html
+++ b/edx-platform/cabinet-theme/lms/templates/navigation/navbar-not-authenticated.html
@@ -72,7 +72,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
       % if settings.FEATURES.get('ENABLE_FEEDBACK_SUBMISSION', False):
         <li><a href="#" data-toggle="modal" data-target="#supportModal">${_("Support")}</a></li>
       % endif
-      <li><a href="mailto:commselearning@cabinetoffice.gov.uk" target="_blank">${_("Contact")}</a></li>
+      <li><a href="${marketing_link('FAQ')}" target="_blank">${_("FAQ")}</a></li>
     </ul>
 
   </div>

--- a/edx-platform/cabinet-theme/lms/templates/static_templates/faq.html
+++ b/edx-platform/cabinet-theme/lms/templates/static_templates/faq.html
@@ -1,0 +1,16 @@
+<%page expression_filter="h"/>
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="../main.html" />
+
+<%block name="pagetitle">${_("FAQ")}</%block>
+
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="container about">
+        <h1>
+            <%block name="pageheader">${page_header or _("FAQ")}</%block>
+        </h1>
+        <p>
+            <%block name="pagecontent">${page_content or _("This page left intentionally blank. Feel free to add your own content.")}</%block>
+        </p>
+    </section>
+</main>

--- a/edx-platform/cabinet-theme/lms/templates/static_templates/faq.html
+++ b/edx-platform/cabinet-theme/lms/templates/static_templates/faq.html
@@ -6,11 +6,41 @@
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="container about">
-        <h1>
-            <%block name="pageheader">${page_header or _("FAQ")}</%block>
-        </h1>
-        <p>
-            <%block name="pagecontent">${page_content or _("This page left intentionally blank. Feel free to add your own content.")}</%block>
-        </p>
+        <h1>${_("FAQ")}</h1>
+
+        <p><b>${_("What do I do if I have technical issues?")}</b></p>
+        
+        <p>${_("If you need technical support, please click on the dropdown menu icon in the top right, then choose 'Support' (please attach a screenshot showing the issue and the URL link if possible). Your message will go directly to our Support Team.")}</p>
+        <p>${_("You may also wish to use the Google Chrome browser if you are not doing so already. All course content, activities and videos are best supported by Google Chrome browser.")}</p>
+
+        <p><b>${_("I've reset my password, but I still can't log in")}</b></p>
+		
+        <p>${_("Try resetting your password using the Google Chrome browser or an Incognito Window.")}</p>
+        <p>${_("If you are still unable to reset your password, please contact our Support Team by clicking on the dropdown menu icon in the top right, then choose Support.")}</p>
+
+        <p><b>${_("I'm unable to submit my query using the Support tab")}</b></p>
+		        
+        <p>${_("Use the Google Chrome browser if you are not doing so already.")}</p>
+        <p>${_("If you are still unable to submit your query, contact your course administrator.")}</p>
+
+        <p><b>${_("My account is locked and I'm unable to access the learning platform.")}</b></p>
+		
+        <p>${_("Your account may be locked if you have tried to log in unsuccessfully too many times over a short period. Please wait an hour before logging onto the platform again.")}</p>
+        <p>${_("If the platform does not recognise your password, it is better to reset it before making another attempt to log onto the course.")}</p>
+
+        <p><b>${_("Why don't the green checkmarks appear to record that I've completed a screen, even though I have worked through all the course materials?")}</b></p>
+        <p>${_("The green checkmarks showing that a section has been completed may not appear due to a variety of reasons. These are likely to be technical factors such as the browser you are using, or the quality of your internet connection. ")}</p>
+        <p>${_("Use the Google Chrome browser if you are not doing so already.")}</p>
+        <p>${_("Please note that the green checkmarks are a visual aid for you to indicate your progress through the course. If the green checkmarks do not appear, this will not prevent you from completing the course in full or receiving your certificate.")}</p>
+
+        <p><b>${_("How do I find what I need on the platform?")}</b></p>
+		
+        <p><b>${_("Your Dashboard - ")}</b>${_("click on the dropdown menu icon in the top right, then choose 'Dashboard'. You will be able to see any courses that you are enrolled in here. ")}</p>
+        <p>${_("You can access your courses on this Dashboard page.")}</p>
+
+        <p><b>${_("Language option - ")}</b>${_("when you are logged into the EdX platform, at the top of the screen next to your name you should see a separate button showing which language is currently being used. By clicking this button, you will then be able to select a language you want to have your course displayed in.")}</p>
+        <p>${_("You can also set your course language if you click on the dropdown menu icon in the top right, then choose 'Account'. A further dropdown menu on this screen will allow you to change languages.")}</p>
+
+        <p><b>${_("Support Tab - ")}</b>${_("if you need technical support, please request this within the platform; click on the dropdown menu icon in the top right, then choose 'Support' (please attach a screenshot showing the issue and the URL link if possible). Your message will go directly to our Support Team.")}</p>
     </section>
 </main>

--- a/edx-platform/cabinet-theme/lms/templates/static_templates/honor.html
+++ b/edx-platform/cabinet-theme/lms/templates/static_templates/honor.html
@@ -5,7 +5,9 @@
 <%!
 from django.utils.translation import ugettext as _
 from microsite_configuration import microsite
-platform_name = microsite.get_value('PLATFORM_NAME', '')
+from django.conf import settings
+platform_name = settings.PLATFORM_NAME
+
 %>
 
 <%block name="title"><title>${_("Terms of Service and Honor Code")}</title></%block>

--- a/edx-platform/cabinet-theme/lms/templates/user_dropdown.html
+++ b/edx-platform/cabinet-theme/lms/templates/user_dropdown.html
@@ -115,7 +115,7 @@ from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_
         % if settings.FEATURES.get('ENABLE_FEEDBACK_SUBMISSION', False):
             <li><a href="#" data-toggle="modal" data-target="#supportModal">${_("Support")}</a></li>
         % endif
-        <li><a href="mailto:commselearning@cabinetoffice.gov.uk" target="_blank">${_("Contact")}</a></li>
+        <li><a href="${marketing_link('FAQ')}" target="_blank">${_("FAQ")}</a></li>
         <!-- <li><a href="${get_online_help_info(online_help_token)['doc_url']}" target="_blank">${_("Help")}</a></li> -->
         % if false:
             <li>


### PR DESCRIPTION
This PR replaces all instances of the "Contact" link by a link t to the "FAQ" page. And adds the appropriate text to the FAQ.

 Also, it fixes a variable in the honor page (now it takes the platform name from the global variables, since there is only one site in Cabinet).